### PR TITLE
Fix ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,6 @@ jobs:
   build-and-test:
     name: Build and Test
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -37,7 +36,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: build-and-test
     if: github.ref == 'refs/heads/main'
-
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -46,6 +44,9 @@ jobs:
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '8.0.x'
+
+      - name: Restore package to pack
+        run: dotnet restore src/NexMediator.Core/NexMediator.Core.csproj
 
       - name: Pack NexMediator.Core
         run: |


### PR DESCRIPTION
## Description
Added a `dotnet restore` step before `dotnet pack` in the CI workflow’s **pack-and-publish** job to ensure `project.assets.json` is generated and prevent the “Assets file not found” error.

## Checklist
- [x] Code follows the conventions  
- [ ] Tests have been added or updated  

