### PR TITLE
fix: add build step before pack in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ jobs:
   build-and-test:
     name: Build and Test
     runs-on: ubuntu-latest
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -36,6 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: build-and-test
     if: github.ref == 'refs/heads/main'
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -45,8 +47,11 @@ jobs:
         with:
           dotnet-version: '8.0.x'
 
-      - name: Restore package to pack
+      - name: Restore package project
         run: dotnet restore src/NexMediator.Core/NexMediator.Core.csproj
+
+      - name: Build package project
+        run: dotnet build src/NexMediator.Core/NexMediator.Core.csproj --configuration Release
 
       - name: Pack NexMediator.Core
         run: |


### PR DESCRIPTION
## Description
Merged `fix` into `develop` and updated the CI workflow to add a `dotnet build` step before `dotnet pack`. This ensures the compiled DLL is present and prevents the “file not found” error during packaging.

## Checklist
- [x] Code follows the conventions  
- [ ] Tests have been added or updated  

